### PR TITLE
Fix python resource paths and followup to b1f8b8a13eb

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -47,12 +47,12 @@ endmacro(create_demo demo_name)
 create_demo(
   solo12
   solo12
-  ${PythonModules_robot_properties_solo_PATH}/robot_properties_solo/robot_properties_solo/dynamic_graph_manager/dgm_parameters_solo12.yaml
+  ${PythonModules_robot_properties_solo_PATH}/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
 )
 create_demo(
   solo8
   solo8
-  ${PythonModules_robot_properties_solo_PATH}/robot_properties_solo/robot_properties_solo/dynamic_graph_manager/dgm_parameters_solo8.yaml
+  ${PythonModules_robot_properties_solo_PATH}/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo8.yaml
 )
 
 if (BUILD_SOLO8_TI)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ if(${dynamic_graph_manager_FOUND} AND BUILD_ROS_DYNAMIC_GRAPH)
     string(
     CONCAT dgm_yaml_path
          "${PythonModules_robot_properties_solo_PATH}/"
-         "robot_properties_solo/robot_properties_solo/dynamic_graph_manager/")
+         "robot_properties_solo/resources/dynamic_graph_manager/")
     target_compile_definitions(dg_main_${robot_name}
       PUBLIC ROBOT_PROPERTIES_YAML_PATH="${dgm_yaml_path}")
     # Export the target.

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -139,7 +139,7 @@ void Solo12::initialize(const std::string& network_id,
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE};
     calib_ctrl_ = std::make_shared<odri_control_interface::JointCalibrator>(
-        robot_->joints, directions, position_offsets, 5., 0.05, 1.0, 0.001);
+        joints_, directions, position_offsets, 5., 0.05, 1.0, 0.001);
 
     // Define the robot.
     robot_ = std::make_shared<odri_control_interface::Robot>(

--- a/src/solo8.cpp
+++ b/src/solo8.cpp
@@ -121,7 +121,7 @@ void Solo8::initialize(const std::string& network_id)
         odri_control_interface::POSITIVE
        };
     calib_ctrl_ = std::make_shared<odri_control_interface::JointCalibrator>(
-        robot_->joints, directions, position_offsets, 5., 0.05, 1.0, 0.001);
+        joints_, directions, position_offsets, 5., 0.05, 1.0, 0.001);
 
     // Define the robot.
     robot_ = std::make_shared<odri_control_interface::Robot>(


### PR DESCRIPTION
- This fixes path changes in robot_properties_solo from https://github.com/open-dynamic-robot-initiative/robot_properties_solo/pull/45
- This fixes a null-pointer dereferencing introduced from b1f8b8a13eb