### PR TITLE
Add ability to use on-board PD controller with Solo12

### DIFF
--- a/include/solo/dynamic_graph_manager/dgm_solo12.hpp
+++ b/include/solo/dynamic_graph_manager/dgm_solo12.hpp
@@ -106,6 +106,28 @@ private:
     solo::Vector12d ctrl_joint_torques_;
 
     /**
+     * @brief Desired joint positions for the PD controller running on the
+     * udriver board.
+     */
+    solo::Vector12d ctrl_joint_positions_;
+
+    /**
+     * @brief Desired joint velocities for the PD controller running on the
+     * udriver board.
+     */
+    solo::Vector12d ctrl_joint_velocities_;
+
+    /**
+     * @brief P gains for the PD controller running on the udriver board.
+     */
+    solo::Vector12d joint_position_gains_;
+
+    /**
+     * @brief D gains for the PD controller running on the udriver board.
+     */
+    solo::Vector12d joint_velocity_gains_;
+
+    /**
      * @brief Check if we entered once in the safety mode and stay there if so
      */
     bool was_in_safety_mode_;

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -77,6 +77,34 @@ public:
         const Eigen::Ref<Vector12d> target_joint_torque);
 
     /**
+     * @brief Sets the desired joint position of the P controller running on
+     * the card.
+     */
+    void send_target_joint_position(
+        const Eigen::Ref<Vector12d> target_joint_position);
+
+    /**
+     * @brief Sets the desired joint velocity of the D controller running on
+     * the card.
+     */
+    void send_target_joint_velocity(
+        const Eigen::Ref<Vector12d> target_joint_velocity);
+
+    /**
+     * @brief Sets the desired joint position gain P for the P controller
+     * running on the card.
+     */
+    void send_target_joint_position_gains(
+        const Eigen::Ref<Vector12d> target_joint_position_gains);
+
+    /**
+     * @brief Sets the desired joint velocity gain D for the D controller
+     * running on the card.
+     */
+    void send_target_joint_velocity_gains(
+        const Eigen::Ref<Vector12d> target_joint_velocity_gains);
+
+    /**
      * @brief acquire_sensors acquire all available sensors, WARNING !!!!
      * this method has to be called prior to any getter to have up to date data.
      */

--- a/src/dynamic_graph_manager/dgm_solo12.cpp
+++ b/src/dynamic_graph_manager/dgm_solo12.cpp
@@ -154,11 +154,23 @@ void DGMSolo12::set_motor_controls_from_map(
 {
     try
     {
-        // Here we need to perform and internal copy. Otherwise the compilator
+        // Here we need to perform an internal copy. Otherwise the compiler
         // complains.
         ctrl_joint_torques_ = map.at("ctrl_joint_torques");
         // Actually send the control to the robot.
         solo_.send_target_joint_torque(ctrl_joint_torques_);
+
+        ctrl_joint_positions_ = map.at("ctrl_joint_positions");
+        solo_.send_target_joint_position(ctrl_joint_positions_);
+
+        ctrl_joint_velocities_ = map.at("ctrl_joint_velocities");
+        solo_.send_target_joint_velocity(ctrl_joint_velocities_);
+
+        joint_position_gains_ = map.at("ctrl_joint_position_gains");
+        solo_.send_target_joint_position_gains(joint_position_gains_);
+
+        joint_velocity_gains_ = map.at("ctrl_joint_velocity_gains");
+        solo_.send_target_joint_velocity_gains(joint_velocity_gains_);
     }
     catch (const std::exception& e)
     {

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -272,6 +272,30 @@ void Solo12::send_target_joint_torque(
     }
 }
 
+void Solo12::send_target_joint_position(
+    const Eigen::Ref<Vector12d> target_joint_position)
+{
+    robot_->joints->SetDesiredPositions(target_joint_position);
+}
+
+void Solo12::send_target_joint_velocity(
+        const Eigen::Ref<Vector12d> target_joint_velocity)
+{
+    robot_->joints->SetDesiredVelocities(target_joint_velocity);
+}
+
+void Solo12::send_target_joint_position_gains(
+    const Eigen::Ref<Vector12d> target_joint_position_gains)
+{
+    robot_->joints->SetPositionGains(target_joint_position_gains);
+}
+
+void Solo12::send_target_joint_velocity_gains(
+    const Eigen::Ref<Vector12d> target_joint_velocity_gains)
+{
+    robot_->joints->SetVelocityGains(target_joint_velocity_gains);
+}
+
 void Solo12::wait_until_ready()
 {
     real_time_tools::Spinner spinner;


### PR DESCRIPTION
## Description

Expose interface to use the on-board PD controller with Solo12.


## How I Tested

On the test bench using a modified version of the dynamic_graph_head example.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
