### PR TITLE
solo12: Forward lost packet count with sensor data

### DIFF
--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <slider_box/serial_reader.hpp>
 #include <odri_control_interface/calibration.hpp>
 #include <odri_control_interface/robot.hpp>
+#include <slider_box/serial_reader.hpp>
 #include "solo/common_header.hpp"
 
 namespace solo
@@ -357,6 +357,38 @@ public:
     bool is_calibrating()
     {
         return _is_calibrating;
+    }
+
+    /**
+     * @brief Get total number of command packets sent to the robot.
+     */
+    int get_num_sent_command_packets() const
+    {
+        return main_board_ptr_->GetCmdSent();
+    }
+
+    /**
+     * @brief Get number of lost command packets.
+     */
+    int get_num_lost_command_packets() const
+    {
+        return main_board_ptr_->GetCmdLost();
+    }
+
+    /**
+     * @brief Get total number of sensor packets sent by the robot.
+     */
+    int get_num_sent_sensor_packets() const
+    {
+        return main_board_ptr_->GetSensorsSent();
+    }
+
+    /**
+     * @brief Get number of lost sensor packets.
+     */
+    int get_num_lost_sensor_packets() const
+    {
+        return main_board_ptr_->GetSensorsLost();
     }
 
 private:

--- a/src/dynamic_graph_manager/dgm_solo12.cpp
+++ b/src/dynamic_graph_manager/dgm_solo12.cpp
@@ -147,6 +147,16 @@ void DGMSolo12::get_sensors_to_map(dynamic_graph_manager::VectorDGMap& map)
         map_motor_board_enabled[i] = motor_board_enabled[i];
         map_motor_board_errors[i] = motor_board_errors[i];
     }
+
+    /*
+     * Connection quality
+     */
+    map.at("num_sent_command_packets")[0] =
+        solo_.get_num_sent_command_packets();
+    map.at("num_lost_command_packets")[0] =
+        solo_.get_num_lost_command_packets();
+    map.at("num_sent_sensor_packets")[0] = solo_.get_num_sent_sensor_packets();
+    map.at("num_lost_sensor_packets")[0] = solo_.get_num_lost_sensor_packets();
 }
 
 void DGMSolo12::set_motor_controls_from_map(


### PR DESCRIPTION
## Description

Add the sent/lost packets statistics, which is collected by the
MasterBoardInterface, to the sensor data of Solo12.  This way, they are
accessible by the user and can be used to analyse the connection quality
(relevant mostly for wireless connection).

## How I Tested

By printing the values in one of the example scripts.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
