### PR TITLE
Adapt to changed interface of JointCalibrator

### DIFF
--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -1,8 +1,8 @@
 #include "solo/solo12.hpp"
 #include <cmath>
 #include <odri_control_interface/common.hpp>
-#include "solo/common_programs_header.hpp"
 #include "real_time_tools/spinner.hpp"
+#include "solo/common_programs_header.hpp"
 
 namespace solo
 {
@@ -79,8 +79,7 @@ void Solo12::initialize(const std::string& network_id,
     network_id_ = network_id;
 
     // Use a serial port to read slider values.
-    serial_reader_ =
-        std::make_shared<slider_box::SerialReader>(serial_port, 5);
+    serial_reader_ = std::make_shared<slider_box::SerialReader>(serial_port, 5);
 
     main_board_ptr_ = std::make_shared<MasterBoardInterface>(network_id_);
 
@@ -290,7 +289,7 @@ void Solo12::send_target_joint_position(
 }
 
 void Solo12::send_target_joint_velocity(
-        const Eigen::Ref<Vector12d> target_joint_velocity)
+    const Eigen::Ref<Vector12d> target_joint_velocity)
 {
     robot_->joints->SetDesiredVelocities(target_joint_velocity);
 }
@@ -312,7 +311,7 @@ void Solo12::wait_until_ready()
     real_time_tools::Spinner spinner;
     spinner.set_period(0.001);
     static long int count_wait_until_ready = 0;
-    while(state_ != Solo12State::ready)
+    while (state_ != Solo12State::ready)
     {
         if (count_wait_until_ready % 200 == 0)
         {

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -123,8 +123,11 @@ void Solo12::initialize(const std::string& network_id,
 
     // Use zero position offsets for now. Gets updated in the calibration
     // method.
-    Eigen::VectorXd position_offsets(12);
+    Eigen::VectorXd position_offsets(12), calibration_position(12);
+    Eigen::VectorXi calibration_order(12);
     position_offsets.fill(0.);
+    calibration_position.fill(0.);
+    calibration_order.fill(0);
     std::vector<odri_control_interface::CalibrationMethod> directions{
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE,
@@ -139,7 +142,15 @@ void Solo12::initialize(const std::string& network_id,
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE};
     calib_ctrl_ = std::make_shared<odri_control_interface::JointCalibrator>(
-        joints_, directions, position_offsets, 5., 0.05, 1.0, 0.001);
+        joints_,
+        directions,
+        position_offsets,
+        calibration_order,
+        calibration_position,
+        5.,
+        0.05,
+        1.0,
+        0.001);
 
     // Define the robot.
     robot_ = std::make_shared<odri_control_interface::Robot>(

--- a/src/solo8.cpp
+++ b/src/solo8.cpp
@@ -1,7 +1,7 @@
 #include "solo/solo8.hpp"
 #include <cmath>
-#include "solo/common_programs_header.hpp"
 #include <odri_control_interface/common.hpp>
+#include "solo/common_programs_header.hpp"
 
 namespace solo
 {
@@ -68,8 +68,7 @@ Solo8::Solo8()
 void Solo8::initialize(const std::string& network_id)
 {
     // Use a serial port to read slider values.
-    serial_reader_ =
-        std::make_shared<slider_box::SerialReader>("Not used", 3);
+    serial_reader_ = std::make_shared<slider_box::SerialReader>("Not used", 3);
 
     main_board_ptr_ = std::make_shared<MasterBoardInterface>(network_id);
 
@@ -81,7 +80,8 @@ void Solo8::initialize(const std::string& network_id)
     double lHFE = 1.45;
     double lKFE = 2.80;
     Eigen::VectorXd joint_lower_limits(8);
-    joint_lower_limits << -lHFE, -lKFE, -lHFE, -lKFE, -lHFE, -lKFE, -lHFE, -lKFE;
+    joint_lower_limits << -lHFE, -lKFE, -lHFE, -lKFE, -lHFE, -lKFE, -lHFE,
+        -lKFE;
     Eigen::VectorXd joint_upper_limits(8);
     joint_upper_limits << lHFE, lKFE, lHFE, lKFE, lHFE, lKFE, lHFE, lKFE;
 

--- a/src/solo8.cpp
+++ b/src/solo8.cpp
@@ -108,8 +108,11 @@ void Solo8::initialize(const std::string& network_id)
 
     // Use zero position offsets for now. Gets updated in the calibration
     // method.
-    Eigen::VectorXd position_offsets(8);
+    Eigen::VectorXd position_offsets(8), calibration_position(8);
+    Eigen::VectorXi calibration_order(8);
     position_offsets.fill(0.);
+    calibration_position.fill(0.);
+    calibration_order.fill(0);
     std::vector<odri_control_interface::CalibrationMethod> directions{
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE,
@@ -118,10 +121,17 @@ void Solo8::initialize(const std::string& network_id)
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE,
         odri_control_interface::POSITIVE,
-        odri_control_interface::POSITIVE
-       };
+        odri_control_interface::POSITIVE};
     calib_ctrl_ = std::make_shared<odri_control_interface::JointCalibrator>(
-        joints_, directions, position_offsets, 5., 0.05, 1.0, 0.001);
+        joints_,
+        directions,
+        position_offsets,
+        calibration_order,
+        calibration_position,
+        5.,
+        0.05,
+        1.0,
+        0.001);
 
     // Define the robot.
     robot_ = std::make_shared<odri_control_interface::Robot>(


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

After [recent updates in odri_control_interface](https://github.com/open-dynamic-robot-initiative/odri_control_interface/pull/16), `JointCalibrator` now expects additional arguments for specifying the order in which joints are handled.
If I understand the meaning of the values correctly, setting them all zero should result in the current behaviour (all joints at once).

(not sure, who would be best for reviewing this, so I simply added everyone from the related PR :) )

## How I Tested

Tested on a Solo12 robot.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
