### PR TITLE
fix: Only export dgm dependency if it was found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,10 @@ set(export_list
     pybind11
     yaml_utils
     Eigen3
-    dynamic_graph_manager
 )
+if(${dynamic_graph_manager_FOUND})
+  set(export_list ${export_list} dynamic_graph_manager)
+endif()
 if(${blmc_drivers_FOUND})
   set(BUILD_SOLO8_TI on)
   set(export_list ${export_list} blmc_driver)


### PR DESCRIPTION
## Description

dynamic_graph_manager is an optional dependency, so it should only be exported as dependency if it was actually found.
This fixes a build error when another package depends on 'solo' in a workspace without dynamic_graph_manager.


## How I Tested

By running `colon build` in a workspace without dynamic_graph_manager.