### PR TITLE
fix: Solo12::is_ready() returned inverted value

### DIFF
--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -314,7 +314,7 @@ void Solo12::wait_until_ready()
 
 bool Solo12::is_ready()
 {
-    return state_ != Solo12State::ready;
+    return state_ == Solo12State::ready;
 }
 
 bool Solo12::request_calibration(const Vector12d& home_offset_rad)


### PR DESCRIPTION
## Description

`Solo12::is_ready()` should return true if state == ready, not the other way round :)

## How I Tested

Cannot really test right now, as the code where I'm using it currently still has other problems.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
