### PR TITLE
Add GitHub workflows for build and documentation

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -1,0 +1,50 @@
+# Build the package and run tests, using the latest solo_user Apptainer
+# image.
+# The Apptainer image has a full ROBOT_INTERFACES_SOLO workspace installed, so
+# all dependencies are there and only the checked package needs to be build, not
+# the whole workspace.
+#
+# Note: The Apptainer image only gets automatically rebuild, if something in the
+# image definition changes, not when other packages are changed.  So to avoid
+# that the workspace in the container gets outdated, manual builds need to be
+# triggered regularly.
+
+name: Build and Test
+
+on:
+  push:
+    branches:
+     - master
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-20.04
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.doc.outputs.page_url }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Apptainer
+        uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2
+        with:
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_user:latest
+
+      - name: Build
+        uses: open-dynamic-robot-initiative/trifinger-build-action/build@v2
+
+      - name: Documentation
+        id: doc
+        uses: open-dynamic-robot-initiative/trifinger-build-action/build_and_deploy_docs@v2
+
+      - name: Tests
+        uses: open-dynamic-robot-initiative/trifinger-build-action/run_tests@v2

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,0 +1,32 @@
+# Build the package and run tests, using the latest solo_user Apptainer
+# image.
+# The Apptainer image has a full ROBOT_INTERFACES_SOLO workspace installed, so
+# all dependencies are there and only the checked package needs to be build, not
+# the whole workspace.
+#
+# Note: The Apptainer image only gets automatically rebuild, if something in the
+# image definition changes, not when other packages are changed.  So to avoid
+# that the workspace in the container gets outdated, manual builds need to be
+# triggered regularly.
+
+name: Build and Test
+
+on: pull_request
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Apptainer
+        uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2
+        with:
+          uri: oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/solo_user:latest
+
+      - name: Build
+        uses: open-dynamic-robot-initiative/trifinger-build-action/build@v2
+
+      - name: Tests
+        uses: open-dynamic-robot-initiative/trifinger-build-action/run_tests@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.user
 *.pyc
-*build*
+build/

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -26,18 +26,19 @@ enum Solo12State
  * @brief Definition and drivers for the Solo12 robot.
  *
  * Mapping between the DOF and driver boards + motor ports:
- * FL_HAA - motor board 0, motor port 0, motor index 0
- * FL_HFE - motor board 1, motor port 1, motor index 3
- * FL_KFE - motor board 1, motor port 0, motor index 2
- * FR_HAA - motor board 0, motor port 1, motor index 1
- * FR_HFE - motor board 2, motor port 1, motor index 5
- * FR_KFE - motor board 2, motor port 0, motor index 4
- * HL_HAA - motor board 3, motor port 0, motor index 6
- * HL_HFE - motor board 4, motor port 1, motor index 9
- * HL_KFE - motor board 4, motor port 0, motor index 8
- * HR_HAA - motor board 3, motor port 1, motor index 7
- * HR_HFE - motor board 5, motor port 1, motor index 11
- * HR_KFE - motor board 5, motor port 0, motor index 10
+ *
+ * - FL_HAA: motor board 0, motor port 0, motor index 0
+ * - FL_HFE: motor board 1, motor port 1, motor index 3
+ * - FL_KFE: motor board 1, motor port 0, motor index 2
+ * - FR_HAA: motor board 0, motor port 1, motor index 1
+ * - FR_HFE: motor board 2, motor port 1, motor index 5
+ * - FR_KFE: motor board 2, motor port 0, motor index 4
+ * - HL_HAA: motor board 3, motor port 0, motor index 6
+ * - HL_HFE: motor board 4, motor port 1, motor index 9
+ * - HL_KFE: motor board 4, motor port 0, motor index 8
+ * - HR_HAA: motor board 3, motor port 1, motor index 7
+ * - HR_HFE: motor board 5, motor port 1, motor index 11
+ * - HR_KFE: motor board 5, motor port 0, motor index 10
  */
 class Solo12
 {

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,10 @@ You find examples for how to use the code base in the `demos/` folder.
 
 #### API documentation
 
-To build the API documentation, please follow the steps [here](https://github.com/machines-in-motion/machines-in-motion.github.io/issues/4).
+The API documentation of the current master branch is provided here:
+https://open-dynamic-robot-initiative.github.io/solo
+
+To build the API documentation yourself, please follow the steps [here](https://github.com/machines-in-motion/machines-in-motion.github.io/issues/4).
 
 ### License and Copyrights
 


### PR DESCRIPTION
## Description

It seems the documentation of this package is currently not hosted anywhere (at least I couldn't find it).  Therefore I'm adding the GitHub workflows that I am already using on the TriFinger-related packages to check pull requests and to build/deploy documentation using GitHub Pages of the repository (so it will be accessible at https://open-dynamic-robot-initiative.github.io/solo).

- `build_pr.yml` runs the build and unit tests on pull requests (to verify the proposed change do not break something).
- `build_master.yml` does the same when something is pushed/merged into master but additionally it also build the documentation and deploys it to the GitHub Pages of the repo.

The Apptainer image used for building contains all the dependencies for robot_properties_solo and should thus also be suitable for this package.

I also made a small formatting fix in the doxygen comment of the `Solo12` class.

## How I Tested

The PR-check will already run on this PR (see checks below).  The build/deployment of the documentation will only happen when merging to master.


## Do not merge before

- [ ] Deployment to Pages via action is enabled for the repo (I'll do this if the PR get's accepted).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
