### PR TITLE
Don't use slider box if port is empty or "none"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(real_time_tools REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(yaml_utils REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(spdlog REQUIRED)
 # Find resources from robot_properties packages.
 find_package(PythonModules COMPONENTS robot_properties_solo)
 
@@ -57,6 +58,7 @@ set(export_list
     pybind11
     yaml_utils
     Eigen3
+    spdlog
 )
 if(${dynamic_graph_manager_FOUND})
   set(export_list ${export_list} dynamic_graph_manager)

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -43,6 +43,8 @@ enum Solo12State
 class Solo12
 {
 public:
+    inline static const std::string SERIAL_PORT_DISABLED = "none";
+
     /**
      * @brief Solo is the constructor of the class.
      */
@@ -476,11 +478,6 @@ private:
      * Can be used as a joystick input.
      */
     Eigen::Vector4d slider_positions_;
-
-    /**
-     * @brief For reading the raw slider values from the serial port.
-     */
-    std::vector<int> slider_positions_vector_;
 
     /**
      * @brief contact_sensors_ is contact sensors at each feet of teh quadruped.

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -53,7 +53,12 @@ public:
     /**
      * @brief Initialize the robot by setting aligning the motors and calibrate
      * the sensors to 0.
-     * @param if_name Interface for connection to hardware.
+     *
+     * @param network_id Name of the network interface for connection to the
+     *      robot.
+     * @param slider_box_port Name of the serial port to which the slider box is
+     *      connected.  Set to "" or "none" if no slider box is used.  Set to
+     *      "auto" to auto-detect the port.
      */
     void initialize(const std::string& network_id,
                     const std::string& slider_box_port);

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -56,7 +56,7 @@ public:
      * @param if_name Interface for connection to hardware.
      */
     void initialize(const std::string& network_id,
-                    const std::string& serial_port);
+                    const std::string& slider_box_port);
 
     /**
      * @brief Sets the maximum joint torques.

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -11,6 +11,7 @@
 #include <odri_control_interface/calibration.hpp>
 #include <odri_control_interface/robot.hpp>
 #include <slider_box/serial_reader.hpp>
+
 #include "solo/common_header.hpp"
 
 namespace solo
@@ -43,7 +44,8 @@ enum Solo12State
 class Solo12
 {
 public:
-    inline static const std::string SERIAL_PORT_DISABLED = "none";
+    //! @brief Set slider box port to this value to disable it.
+    inline static const std::string SLIDER_BOX_DISABLED = "none";
 
     //! @brief Name of the spdlog logger used by the class.
     inline static const std::string LOGGER_NAME = "solo/Solo12";

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -2,11 +2,11 @@
  * \file solo12.hpp
  * \author Julian Viereck
  * \date 21 November 2019
- * \copyright Copyright (c) 2019, New York University and Max Planck
- * Gesellschaft.
+ * \copyright Copyright (c) 2019 New York University & Max Planck Gesellschaft
  */
-
 #pragma once
+
+#include <spdlog/spdlog.h>
 
 #include <odri_control_interface/calibration.hpp>
 #include <odri_control_interface/robot.hpp>
@@ -44,6 +44,9 @@ class Solo12
 {
 public:
     inline static const std::string SERIAL_PORT_DISABLED = "none";
+
+    //! @brief Name of the spdlog logger used by the class.
+    inline static const std::string LOGGER_NAME = "solo/Solo12";
 
     /**
      * @brief Solo is the constructor of the class.
@@ -400,6 +403,9 @@ public:
     }
 
 private:
+    //! Logger
+    std::shared_ptr<spdlog::logger> log_;
+
     /**
      * Joint properties
      */

--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -408,6 +408,9 @@ private:
     //! Logger
     std::shared_ptr<spdlog::logger> log_;
 
+    // Number of values sent by the slider box through the serial port.
+    static constexpr int SLIDER_BOX_NUM_VALUES = 5;
+
     /**
      * Joint properties
      */

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
     <depend>pybind11</depend>
     <depend>yaml_utils</depend>
     <depend>Eigen3</depend>
+    <depend>spdlog</depend>
     <depend>dynamic_graph_manager</depend>
 
     <!-- Python dependencies. -->

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} INTERFACE yaml_utils::yaml_utils)
 target_link_libraries(${PROJECT_NAME} INTERFACE slider_box::slider_box)
 target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)
+target_link_libraries(${PROJECT_NAME} INTERFACE spdlog::spdlog)
 # Export the target.
 list(APPEND all_src_targets ${PROJECT_NAME})
 

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -73,16 +73,16 @@ Solo12::Solo12()
 }
 
 void Solo12::initialize(const std::string& network_id,
-                        const std::string& serial_port)
+                        const std::string& slider_box_port)
 {
     network_id_ = network_id;
 
     // only initialize serial reader if
-    if (!serial_port.empty() and serial_port != SERIAL_PORT_DISABLED)
+    if (!slider_box_port.empty() and slider_box_port != SERIAL_PORT_DISABLED)
     {
         // Use a serial port to read slider values.
         serial_reader_ =
-            std::make_shared<slider_box::SerialReader>(serial_port, 5);
+            std::make_shared<slider_box::SerialReader>(slider_box_port, 5);
     }
 
     main_board_ptr_ = std::make_shared<MasterBoardInterface>(network_id_);

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -1,5 +1,9 @@
 #include "solo/solo12.hpp"
+
 #include <cmath>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+
 #include <odri_control_interface/common.hpp>
 #include "real_time_tools/spinner.hpp"
 #include "solo/common_programs_header.hpp"
@@ -12,6 +16,14 @@ using namespace odri_control_interface;
 
 Solo12::Solo12()
 {
+    // initialise logger and set level
+    log_ = spdlog::get(LOGGER_NAME);
+    if (!log_)
+    {
+        log_ = spdlog::stderr_color_mt(LOGGER_NAME);
+        log_->set_level(spdlog::level::debug);
+    }
+
     /**
      * Hardware properties
      */
@@ -80,9 +92,14 @@ void Solo12::initialize(const std::string& network_id,
     // only initialize serial reader if
     if (!slider_box_port.empty() and slider_box_port != SERIAL_PORT_DISABLED)
     {
+        log_->debug("Use slider box at port '{}'", slider_box_port);
         // Use a serial port to read slider values.
         serial_reader_ =
             std::make_shared<slider_box::SerialReader>(slider_box_port, 5);
+    }
+    else
+    {
+        log_->info("No slider box port provided.  Slider box is disabled.");
     }
 
     main_board_ptr_ = std::make_shared<MasterBoardInterface>(network_id_);

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -90,7 +90,7 @@ void Solo12::initialize(const std::string& network_id,
     network_id_ = network_id;
 
     // only initialize serial reader if
-    if (!slider_box_port.empty() and slider_box_port != SERIAL_PORT_DISABLED)
+    if (!slider_box_port.empty() and slider_box_port != SLIDER_BOX_DISABLED)
     {
         log_->debug("Use slider box at port '{}'", slider_box_port);
         // Use a serial port to read slider values.

--- a/src/solo12.cpp
+++ b/src/solo12.cpp
@@ -94,8 +94,8 @@ void Solo12::initialize(const std::string& network_id,
     {
         log_->debug("Use slider box at port '{}'", slider_box_port);
         // Use a serial port to read slider values.
-        serial_reader_ =
-            std::make_shared<slider_box::SerialReader>(slider_box_port, 5);
+        serial_reader_ = std::make_shared<slider_box::SerialReader>(
+            slider_box_port, SLIDER_BOX_NUM_VALUES);
     }
     else
     {
@@ -209,7 +209,7 @@ void Solo12::acquire_sensors()
      */
     if (serial_reader_)
     {
-        std::vector<int> slider_box_values(5);
+        std::vector<int> slider_box_values(SLIDER_BOX_NUM_VALUES);
 
         // acquire the slider positions
         // TODO: Handle case that no new values are arriving.


### PR DESCRIPTION
## Description

Currently the slider box must always be connected, even if not used, otherwise the robot doesn't run.  Since often it is not actually needed, change this to only use the slider box if the serial port is set to a non-empty value unequal "none".

Resolves #118.

Also some refactoring of the related code.

Note that **this is a breaking change**. Existing configurations which currently have the port set to an empty string but intend to use the slider box need to be updated.  I added an output if the slider box is disabled, to make it more obvious what is going on.

## How I Tested

Tested in conjunction with https://github.com/open-dynamic-robot-initiative/slider_box/pull/2 on the test bench with all possible configurations.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
