### PR TITLE
fix!: Use `enum class` for SoloXState

### DIFF
--- a/include/solo/solo12.hpp
+++ b/include/solo/solo12.hpp
@@ -16,7 +16,7 @@
 
 namespace solo
 {
-enum Solo12State
+enum class Solo12State
 {
     initial,
     ready,

--- a/include/solo/solo8.hpp
+++ b/include/solo/solo8.hpp
@@ -15,7 +15,7 @@
 
 namespace solo
 {
-enum Solo8State
+enum class Solo8State
 {
     initial,
     ready,


### PR DESCRIPTION
## Description

This is needed to allow including solo8.hpp and solo12.hpp together.

BREAKING CHANGE: This change breaks existing code if it is directly using the enum members (i.e. just `initial` instead of `Solo12State::initial`).


## How I Tested

Compiled ROBOT_INTERFACES_SOLO workspace